### PR TITLE
Instantiate multiple MenuItemModel objects

### DIFF
--- a/tests/MenuItemInstantiation.test.js
+++ b/tests/MenuItemInstantiation.test.js
@@ -1,0 +1,22 @@
+import MenuItemModel from "../core/models/MenuItemModel.js";
+
+describe("MenuItemModel Instantiation", () => {
+
+    // Instantiate multiple MenuItem objects
+    const burger = new MenuItemModel("Burger", 8.99);
+    const pizza = new MenuItemModel("Pizza", 12.99);
+    const fries = new MenuItemModel("Fries", 4.99);
+    const soda = new MenuItemModel("Soda", 2.49);
+    const salad = new MenuItemModel("Salad", 6.99);
+
+    test("Objects should be created correctly", () => {
+
+        expect(burger).toBeDefined();
+        expect(pizza).toBeDefined();
+        expect(fries).toBeDefined();
+        expect(soda).toBeDefined();
+        expect(salad).toBeDefined();
+
+    });
+
+});


### PR DESCRIPTION
Instantiated multiple MenuItemModel objects in a test file.

Purpose:
This demonstrates that the MenuItemModel can create multiple menu items successfully.